### PR TITLE
feat(screen): add enhanced keyboard mode helpers

### DIFF
--- a/lib/termite/screen.ex
+++ b/lib/termite/screen.ex
@@ -211,6 +211,23 @@ defmodule Termite.Screen do
   end
 
   @doc """
+  Enable enhanced keyboard reporting.
+
+  This currently enables Kitty keyboard protocol basic disambiguation and xterm
+  `modifyOtherKeys` mode 2.
+  """
+  def enable_enhanced_keyboard(term) do
+    write(term, "\e[>1u\e[>4;2m")
+  end
+
+  @doc """
+  Disable enhanced keyboard reporting.
+  """
+  def disable_enhanced_keyboard(term) do
+    write(term, "\e[<u\e[>4;0m")
+  end
+
+  @doc """
   Alters the terminal tab or window title. OSC Compatible terminals only.
   """
   def title(term, title) do

--- a/test/termite/screen_test.exs
+++ b/test/termite/screen_test.exs
@@ -1,4 +1,23 @@
 defmodule Termite.ScreenTest do
   use ExUnit.Case, async: true
   doctest Termite.Screen
+
+  alias Termite.Screen
+
+  defmodule TestAdapter do
+    def write(pid, data) do
+      send(pid, {:terminal_write, data})
+      {:ok, pid}
+    end
+  end
+
+  test "enhanced keyboard writes the keyboard reporting sequences" do
+    terminal = %Termite.Terminal{adapter: {TestAdapter, self()}}
+
+    assert %Termite.Terminal{} = Screen.enable_enhanced_keyboard(terminal)
+    assert_receive {:terminal_write, "\e[>1u\e[>4;2m"}
+
+    assert %Termite.Terminal{} = Screen.disable_enhanced_keyboard(terminal)
+    assert_receive {:terminal_write, "\e[<u\e[>4;0m"}
+  end
 end


### PR DESCRIPTION
Expose Termite.Screen.enable_enhanced_keyboard/1 and Termite.Screen.disable_enhanced_keyboard/1 for applications that need disambiguated modified key input.

Keep the Kitty keyboard protocol and xterm modifyOtherKeys escape sequences internal to Termite.Screen, and cover the emitted sequences with a focused screen test.